### PR TITLE
Fix ValueError in run.py when hardware does not support SVE but compiler does.

### DIFF
--- a/run.py
+++ b/run.py
@@ -189,6 +189,16 @@ def check_hardware(isa_set, freq, set_freq, verbose, precision, l1_size, l2_size
         except subprocess.CalledProcessError as e:
             print("SVE Compiler Error Output:", e.stderr.decode("utf-8"))
         if not os.path.exists(sve_ex):
+            SVE_SUPPORT_FLAG = False
+        else:
+            try:
+                result = subprocess.run([sve_ex], stdout=subprocess.PIPE)
+            except subprocess.CalledProcessError as e:
+                print("SVE Execution Error Output:", e.stderr.decode("utf-8"))
+
+            SVE_SUPPORT_FLAG = result.returncode == 0
+        
+        if not SVE_SUPPORT_FLAG:
             if (verbose > 2):
                 print("Vector Instruction ISAs Supported: NEON")
             if "sve" in isa_set:
@@ -204,11 +214,6 @@ def check_hardware(isa_set, freq, set_freq, verbose, precision, l1_size, l2_size
                 isa_set.remove("auto")
             return isa_set, int(l1_size), int(l2_size), int(l3_size), int(VLEN), int(LMUL)
         else:
-            try:
-                result = subprocess.run([sve_ex], stdout=subprocess.PIPE)
-            except subprocess.CalledProcessError as e:
-                print("SVE Execution Error Output:", e.stderr.decode("utf-8"))
-
             VLEN_Check = int(result.stdout.decode('utf-8'))
             os.remove(sve_ex)
             if (verbose > 2):


### PR DESCRIPTION
**Description:**

When the compiler supports SVE but the hardware does not, running `SVE_Vector` results in an `Illegal instruction (core dumped)` error. This causes `run.py` line 212:

```python
VLEN_Check = int(result.stdout.decode('utf-8'))
```

to raise a `ValueError` because `result.stdout` is empty due to the failed execution.

To address this issue, I modified the logic to consider both the `returncode` of the subprocess and whether `SVE_Vector` was successfully compiled, in order to determine if the platform truly supports SVE. This prevents the `ValueError`.

**Changes:**

* Added a check for `result.returncode` before parsing `result.stdout`
* Updated the SVE support detection flow accordingly
