### PR TITLE
Merge dev: ISA registration refactor, persist GUI settings, export plot as SVG, plot quality improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ carm_roofline/            Main Python package
 │   ├── interface.py      run_full_benchmark() orchestration
 │   └── benchmarking.py   Benchmarking config (TestType, CLI args)
 ├── core/                 Domain primitives (DataType, Operation, UserError, type-safe units)
-├── isa/                  ISA identity hierarchy (BaseISA, ALL_ISAS, ISA_NAME_TO_CLASS)
+├── isa/                  ISA identity hierarchy (BaseISA, from_name, all)
 ├── test_bench/           C measurement harness (builder.py, test_bench.c/h, wrapper.inl)
 ├── profiling/            PAPI/perf application profiling pipeline
 ├── gui/                  Dash+Plotly interactive roofline dashboard
@@ -142,11 +142,15 @@ exec_iface.compile(...)
 
 ### ISA Registration
 
-ISAs register via explicit tuples in `carm_roofline/isa/__init__.py`:
+ISAs register themselves via `register=True` on the class statement. The registry is accessible through `BaseISA`:
 
 ```python
-ALL_ISAS = (ArmScalar, ArmNeon, ArmSVE, RISCVScalar, RISCV_RVV_071, RISCV_RVV, X86Scalar, ...)
-ISA_NAME_TO_CLASS = {"x86_avx2": X86AVX2, ...}
+class MyISA(BaseISA, register=True):
+    name = "my_isa"
+
+BaseISA.names()        # ["my_isa", ...]
+BaseISA.from_name("my_isa")  # MyISA
+BaseISA.all()          # (MyISA, ...)
 INCOMPATIBLE_ISAS = {frozenset({RISCV_RVV_071, RISCV_RVV})}
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ pyproject.toml            Single source of truth: dependencies, ruff, mypy, pyte
 .pre-commit-config.yaml   Pre-commit hooks (ruff, mypy, clang-format, trailing-whitespace)
 ```
 
-## Development Commands
+## Development Commands (QA gate)
 
 ```bash
 # Run benchmarks (auto-detects all ISAs)
@@ -178,3 +178,4 @@ Generic arithmetic wrapper `Unit[T]` (ABC) with subclasses: `Bytes`, `Operations
 - **Mocking**: lightweight — `unittest.mock.Mock` for context, `monkeypatch` for module-level intercepts
 - **Dominant pattern**: parametrized ISA cross-product tests via `@pytest.mark.parametrize`
 - **Categories**: Unit (`test/unit/`, marked `unit`) for profiling model, CLI smoke, register abstraction, ISA helpers. Integration-ish (`test/` root, no markers) for ISA codegen (11-ISA matrix), typed benchmarks, output handlers, memory suite generation.
+Static analysis (`mypy .` and `ruff check`) is a hard gate: no plan should consider code changes done until both pass on changed code. See `RULES.md` for the full tooling-expectations policy.

--- a/carm_roofline/architecture/AGENTS.md
+++ b/carm_roofline/architecture/AGENTS.md
@@ -38,7 +38,7 @@ def __init__(args):
          → Call native_detect(num_threads) to auto-detect
     4. Else:
          → Call detect_for_isa(first_isa, num_threads)
-    5. Import ISA_NAME_TO_CLASS from isa
+    5. Use BaseISA.from_name() for name-to-class lookup
     6. Call _replace_and_warn() to merge detected + user args
     7. If --isa is explicitly provided, validate compatibility via check_isa_compatibility()
     8. Build ISA class list and ISAFrequencies object
@@ -115,7 +115,7 @@ Validates ISA selection using family-based approach:
 ### Command-Line Arguments
 
 Via `insert_arguments()` static method:
-- `-i/--isa` - ISA names (nargs="*", zero or more, choices from ISA_NAME_TO_CLASS)
+- `-i/--isa` - ISA names (nargs="*", zero or more, choices from BaseISA.names())
 - `--topology-config` - Path to TOML topology file (`total_cpus`/`smt_degree`/`cpu_offset` + `[[cache_levels]]`)
     - If omitted: auto-detected from hardware topology when available
     - Example: `--topology-config cpu-topology.toml`

--- a/carm_roofline/architecture/architecture.py
+++ b/carm_roofline/architecture/architecture.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from carm_roofline.arguments import InsertsArguments, positive_int
 from carm_roofline.core import Frequency, UserError
-from carm_roofline.isa import INCOMPATIBLE_ISAS, ISA_NAME_TO_CLASS
+from carm_roofline.isa import INCOMPATIBLE_ISAS, BaseISA
 from carm_roofline.output_utils import configure_verbosity, debug, detail, format_if_container, warn
 
 if TYPE_CHECKING:
@@ -248,9 +248,9 @@ class Architecture(InsertsArguments):
             detected = native_detect(threads=num_threads)
             isa_strs = detected.isa or []
 
-            self.isa: list[type[BaseISA]] = [ISA_NAME_TO_CLASS[isa_str] for isa_str in isa_strs]
+            self.isa: list[type[BaseISA]] = [BaseISA.from_name(isa_str) for isa_str in isa_strs]
         else:
-            self.isa = [ISA_NAME_TO_CLASS[isa_name] for isa_name in args.isa]
+            self.isa = [BaseISA.from_name(isa_name) for isa_name in args.isa]
             # Verify that the selected ISAs are compatible
             check_isa_compatibility(self.isa)
             # Detect additional ISA info (VLEN, etc.) for the first ISA
@@ -280,13 +280,13 @@ class Architecture(InsertsArguments):
 
     @staticmethod
     def insert_arguments(parser: argparse.ArgumentParser) -> None:
-        from carm_roofline.isa import ISA_NAME_TO_CLASS
+        from carm_roofline.isa import BaseISA
 
         parser.add_argument(
             "-i",
             "--isa",
             nargs="+",
-            choices=list(ISA_NAME_TO_CLASS.keys()),
+            choices=BaseISA.names(),
             help="Set of ISAs to test. (Default: automatically detects all available ISAs)",
         )
         parser.add_argument(

--- a/carm_roofline/benchmark/generation/AGENTS.md
+++ b/carm_roofline/benchmark/generation/AGENTS.md
@@ -484,25 +484,13 @@ raise BenchParamError("num_ops must be positive")
 
 ### ISA Registry
 
-**ALL_ISAS:**
-Tuple of all ISA classes for iteration:
-```python
-ALL_ISAS = (ArmScalar, ArmNeon, ArmSVE,
-            RISCVScalar, RISCV_RVV_071, RISCV_RVV,
-            X86Scalar, X86SSE, X86AVX, X86AVX2, X86AVX512)
-```
+**ISA Registry:**
 
-**ISA_NAME_TO_CLASS:**
-Dict mapping ISA names to classes:
-```python
-ISA_NAME_TO_CLASS = {
-    "x86_scalar": X86Scalar,
-    "x86_avx2": X86AVX2,
-    "arm_neon": ArmNeon,
-    "riscv_rvv": RISCV_RVV,
-    ...
-}
-```
+ISAs register themselves via `register=True` on the class statement. The registry is accessible through `BaseISA`:
+
+- `BaseISA.from_name(name)` → Look up an ISA class by its name string
+- `BaseISA.names()` → List all registered ISA names
+- `BaseISA.all()` → Tuple of all registered ISA classes
 
 **INCOMPATIBLE_ISAS:**
 Set of ISA pairs that cannot be used together:
@@ -590,18 +578,17 @@ INCOMPATIBLE_ISAS = {
        return base * self.lmul  # Example for RVV LMUL
    ```
 
-8. **Register in __init__.py**:
+8. **Register the ISA**: Add `register=True` to the class definition:
    ```python
-   # Add to ALL_ISAS tuple
-   ALL_ISAS = (..., X86AVX10)
+   class X86AVX10(BaseX86, register=True):
+       name = "x86_avx10"
+       BITS = 512
+   ```
 
-   # Add to ISA_NAME_TO_CLASS dict
-   ISA_NAME_TO_CLASS = {
-       ...,
-       "x86_avx10": X86AVX10,
-   }
+   No changes to `__init__.py` are needed — registration is automatic.
 
-   # Add to INCOMPATIBLE_ISAS if needed
+   Add to `INCOMPATIBLE_ISAS` if needed:
+   ```python
    INCOMPATIBLE_ISAS = {
        ...,
        frozenset({"x86_avx512", "x86_avx10"}),  # Example

--- a/carm_roofline/gui/components.py
+++ b/carm_roofline/gui/components.py
@@ -346,7 +346,7 @@ def build_plot_area() -> html.Div:
             dcc_graph(
                 PlotAreaID.ROOFLINE_PLOT,
                 figure=build_roofline_figure([], []),
-                config={"responsive": True},
+                config={"responsive": True, "toImageButtonOptions": {"format": "svg", "filename": "roofline"}},
             ),
         ],
     )

--- a/carm_roofline/gui/config.py
+++ b/carm_roofline/gui/config.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 from carm_roofline.arguments import InsertsArguments, add_verbose_argument
+from carm_roofline.gui.data import GUISettings
+from carm_roofline.output_utils import warn
 from carm_roofline.results_paths import default_results_root
 
 
@@ -30,3 +33,33 @@ class GUIConfig(InsertsArguments):
         parser.add_argument("--gui-host", default="127.0.0.1", help="Host address for the Dash server")
         parser.add_argument("--gui-port", type=int, default=8050, help="Port for the Dash server")
         parser.add_argument("--gui-debug", action="store_true", help="Enable Dash debug mode")
+
+
+def gui_settings_path() -> Path:
+    """Return the path to the GUI settings JSON file."""
+    from platformdirs import user_config_dir
+
+    return Path(user_config_dir("carm", appauthor=None)) / "gui-settings.json"
+
+
+def load_gui_settings(path: Path) -> GUISettings:
+    """Load GUI settings from a JSON file, returning defaults on failure."""
+    try:
+        data = path.read_text()
+    except FileNotFoundError:
+        return GUISettings()
+    except OSError as exc:
+        warn(f"Failed to read GUI settings from {path}: {exc}")
+        return GUISettings()
+
+    try:
+        return GUISettings.from_dict(json.loads(data))
+    except json.JSONDecodeError as exc:
+        warn(f"Corrupt GUI settings file {path}: {exc}")
+        return GUISettings()
+
+
+def save_gui_settings(path: Path, settings: GUISettings) -> None:
+    """Save GUI settings to a JSON file, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(settings.to_dict(), sort_keys=True))

--- a/carm_roofline/gui/data.py
+++ b/carm_roofline/gui/data.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
 from typing import Any, TypedDict
 
@@ -180,6 +180,22 @@ class RoofStore:
         store.normalize_by_threads = data.get("normalize_by_threads", False)
         store.marker_scale_factor = data.get("marker_scale_factor", 50.0)
         return store
+
+
+@dataclass
+class GUISettings:
+    """Persistent user preferences for the GUI."""
+
+    normalize_by_threads: bool = False
+    marker_scale_factor: float = 50.0
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> GUISettings:
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
 
 
 # Plot data builder

--- a/carm_roofline/gui/data.py
+++ b/carm_roofline/gui/data.py
@@ -212,6 +212,24 @@ _BW_FILL_OPACITIES: dict[str, float] = {
 }
 
 
+# Distinct marker symbols assigned to each application under the same roof
+_APP_MARKER_SYMBOLS: tuple[str, ...] = (
+    "circle",
+    "diamond",
+    "square",
+    "cross",
+    "x",
+    "star",
+    "pentagon",
+    "hexagram",
+    "triangle-up",
+    "triangle-down",
+    "hourglass",
+    "bowtie",
+    "asterisk",
+    "hash",
+)
+
 MIN_MARKER_SIZE: float = 50.0
 
 
@@ -298,6 +316,14 @@ def build_roofline_figure(
         runtime_min = runtime_max = 0.0
     runtime_range = runtime_max - runtime_min
 
+    # Assign a distinct marker symbol per application, consistent across roofs.
+    app_symbol: dict[str, str] = {}
+    if applications_by_id:
+        for roof in roofs:
+            for app_id in roof.app_ids:
+                if app_id not in app_symbol:
+                    app_symbol[app_id] = _APP_MARKER_SYMBOLS[len(app_symbol) % len(_APP_MARKER_SYMBOLS)]
+
     for idx, (roof, model) in enumerate(zip(roofs, models)):
         color = _COLORS[idx % len(_COLORS)]
         roof_divisor = roof.num_threads if (normalize_by_threads and roof.num_threads and roof.num_threads > 0) else 1
@@ -334,7 +360,7 @@ def build_roofline_figure(
                         showlegend=True,
                         marker={
                             "color": color,
-                            "symbol": "circle",
+                            "symbol": app_symbol[app_id],
                             "size": marker_sizes,
                             "sizemode": "area",
                             "opacity": 0.6,

--- a/carm_roofline/gui/factory.py
+++ b/carm_roofline/gui/factory.py
@@ -11,10 +11,11 @@ from dash import ALL, Input, Output, State, callback_context, html
 from dash.exceptions import PreventUpdate
 
 from carm_roofline.gui.components import build_carm_view_panel, build_layout, build_settings_panel
-from carm_roofline.gui.config import GUIConfig
+from carm_roofline.gui.config import GUIConfig, gui_settings_path, load_gui_settings, save_gui_settings
 from carm_roofline.gui.data import (
     ActivePanel,
     DropdownOption,
+    GUISettings,
     RoofConfig,
     RoofStore,
     build_roofline_figure,
@@ -116,6 +117,11 @@ def create_app(config: GUIConfig) -> dash.Dash:
     initial_roof = make_default_roof(opts)
     initial_store = RoofStore(roof_template=initial_roof)
     initial_store.roofs = [initial_roof]
+    # Override defaults with persisted settings
+    saved = load_gui_settings(gui_settings_path())
+    initial_store.normalize_by_threads = saved.normalize_by_threads
+    initial_store.marker_scale_factor = saved.marker_scale_factor
+    debug(f"Loaded GUI settings: {saved}")
 
     app.layout = build_layout(initial_store, opts, app_dropdown_options)
 
@@ -457,6 +463,13 @@ def _register_callbacks(
     ) -> dict[str, Any]:
         store = RoofStore.from_dict(store_data or {})
         store.normalize_by_threads = bool(normalize)
+        save_gui_settings(
+            gui_settings_path(),
+            GUISettings(
+                normalize_by_threads=store.normalize_by_threads,
+                marker_scale_factor=store.marker_scale_factor,
+            ),
+        )
         return store.to_dict()
 
     # 10. Marker scale slider
@@ -472,6 +485,13 @@ def _register_callbacks(
     ) -> dict[str, Any]:
         store = RoofStore.from_dict(store_data or {})
         store.marker_scale_factor = float(scale if scale is not None else 50.0)
+        save_gui_settings(
+            gui_settings_path(),
+            GUISettings(
+                normalize_by_threads=store.normalize_by_threads,
+                marker_scale_factor=store.marker_scale_factor,
+            ),
+        )
         return store.to_dict()
 
     # 12. Sync button styles with active panel

--- a/carm_roofline/isa/__init__.py
+++ b/carm_roofline/isa/__init__.py
@@ -5,30 +5,12 @@ from carm_roofline.isa.base import BaseISA
 from carm_roofline.isa.riscv import RISCV_RVV, RISCV_RVV_071, RISCVScalar
 from carm_roofline.isa.x86 import X86AVX, X86AVX2, X86AVX512, X86SSE, X86Scalar
 
-ALL_ISAS: tuple[type[BaseISA], ...] = (
-    ArmScalar,
-    ArmNeon,
-    ArmSVE,
-    RISCVScalar,
-    RISCV_RVV_071,
-    RISCV_RVV,
-    X86Scalar,
-    X86SSE,
-    X86AVX,
-    X86AVX2,
-    X86AVX512,
-)
-
-ISA_NAME_TO_CLASS: dict[str, type[BaseISA]] = {isa.name: isa for isa in ALL_ISAS}
-
 INCOMPATIBLE_ISAS = {
     frozenset({RISCV_RVV_071, RISCV_RVV}),
 }
 
 __all__ = [
-    "ALL_ISAS",
     "INCOMPATIBLE_ISAS",
-    "ISA_NAME_TO_CLASS",
     "RISCV_RVV",
     "RISCV_RVV_071",
     "X86AVX",

--- a/carm_roofline/isa/arm.py
+++ b/carm_roofline/isa/arm.py
@@ -42,7 +42,7 @@ def _make_float_instructions_scalar() -> dict[Operation, str | _Instruction]:
     }
 
 
-class ArmScalar(BaseArm):
+class ArmScalar(BaseArm, register=True):
     name = "arm"
 
     bench_instructions = TypedInstructions(
@@ -76,7 +76,7 @@ def _make_float_instructions_neon(suf: str) -> dict[Operation, str | _Instructio
     }
 
 
-class ArmNeon(BaseArm):
+class ArmNeon(BaseArm, register=True):
     name = "arm_neon"
 
     bench_instructions = TypedInstructions(
@@ -113,7 +113,7 @@ def _make_float_instructions_sve(suf: str) -> dict[Operation, str | _Instruction
     }
 
 
-class ArmSVE(BaseArm):
+class ArmSVE(BaseArm, register=True):
     name = "arm_sve"
 
     bench_instructions = TypedInstructions(

--- a/carm_roofline/isa/base.py
+++ b/carm_roofline/isa/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from carm_roofline.benchmark.generation.code_gen import ControlInstructions, TypedInstructions, instruction as inst
 from carm_roofline.benchmark.generation.code_gen.register import CyclicRegisterSet, HelperRegisterSet, TypedRegisterSets
@@ -119,6 +119,36 @@ class BaseISA:
     # Fits in a Gracemont uop cache (512 entries)
     instruction_limit: int = 512
     "Maximum number of instructions in a benchmark (inner + outer loops combined)"
+
+    # Registry of concrete ISA implementations, populated via __init_subclass__
+
+    _registry: ClassVar[dict[str, type[BaseISA]]] = {}
+
+    def __init_subclass__(cls, register: bool = False, **kwargs: Any) -> None:
+        """Auto-register concrete ISA subclasses when they pass register=True."""
+        super().__init_subclass__(**kwargs)
+        if register:
+            cls._registry[cls.name] = cls
+
+    @classmethod
+    def from_name(cls, name: str) -> type[BaseISA]:
+        """Look up an ISA class by its name string (e.g., "x86_avx2" -> X86AVX2)."""
+        return cls._registry[name]
+
+    @classmethod
+    def names(cls) -> list[str]:
+        """Return sorted list of all registered ISA name strings."""
+        return sorted(cls._registry)
+
+    @classmethod
+    def all(cls) -> tuple[type[BaseISA], ...]:
+        """Return tuple of all registered ISA classes."""
+        return tuple(cls._registry.values())
+
+    @classmethod
+    def exists(cls, name: str) -> bool:
+        """Check if an ISA name is registered."""
+        return name in cls._registry
 
     bench_instructions: TypedInstructions
     control_instructions: ControlInstructions

--- a/carm_roofline/isa/riscv.py
+++ b/carm_roofline/isa/riscv.py
@@ -45,7 +45,7 @@ class BaseRISCV(BaseISA):
         return f"%({var.asm_name})"
 
 
-class RISCVScalar(BaseRISCV):
+class RISCVScalar(BaseRISCV, register=True):
     # Instructions associated with each data type and operation
     # Instructions are immutable, so we can define them directly here
     bench_instructions = TypedInstructions(
@@ -100,7 +100,7 @@ def _make_float_instructions_rvv() -> dict[Operation, str | _Instruction]:
     }
 
 
-class RISCV_RVV_071(RISCVScalar):
+class RISCV_RVV_071(RISCVScalar, register=True):
     name = "riscv_rvv_0_7_1"
 
     TYPE_TO_VSETVL: Mapping[DataType, str] = {
@@ -172,7 +172,7 @@ class RISCV_RVV_071(RISCVScalar):
         return op.ops() * elements
 
 
-class RISCV_RVV(RISCV_RVV_071):
+class RISCV_RVV(RISCV_RVV_071, register=True):
     name = "riscv_rvv"
 
     # Instructions associated with each data type and operation

--- a/carm_roofline/isa/x86.py
+++ b/carm_roofline/isa/x86.py
@@ -37,7 +37,7 @@ class BaseX86(BaseISA):
         super().__init__(**kwargs)
 
 
-class X86Scalar(BaseX86):
+class X86Scalar(BaseX86, register=True):
     __registers_float = CyclicRegisterSet("%xmm{}", [(0, 15)])
 
     bench_instructions = TypedInstructions(
@@ -72,7 +72,7 @@ class X86Scalar(BaseX86):
         )
 
 
-class X86SSE(X86Scalar):
+class X86SSE(X86Scalar, register=True):
     name = "x86_sse"
     BITS = 128
 
@@ -107,7 +107,7 @@ class X86SSE(X86Scalar):
         return op.ops() * self.BITS // data_type.bits()
 
 
-class X86AVX(X86SSE):
+class X86AVX(X86SSE, register=True):
     name = "x86_avx"
     BITS = 256
 
@@ -143,7 +143,7 @@ class X86AVX(X86SSE):
         )
 
 
-class X86AVX2(X86AVX):
+class X86AVX2(X86AVX, register=True):
     name = "x86_avx2"
     BITS = 256
 
@@ -172,7 +172,7 @@ class X86AVX2(X86AVX):
         super().__init__(**kwargs)
 
 
-class X86AVX512(X86SSE):
+class X86AVX512(X86SSE, register=True):
     name = "x86_avx512"
     BITS = 512
 

--- a/carm_roofline/profiling/config.py
+++ b/carm_roofline/profiling/config.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from carm_roofline.architecture import MachineSignature, detect_machine_signature, generate_run_name
 from carm_roofline.arguments import InsertsArguments, add_verbose_argument, enum_action
 from carm_roofline.core import DataType
-from carm_roofline.isa import ISA_NAME_TO_CLASS, BaseISA
+from carm_roofline.isa import BaseISA
 from carm_roofline.results_paths import default_results_root
 
 
@@ -82,7 +82,7 @@ class ProfileConfig(InsertsArguments):
         self.perf_interval: int | None = args.perf_interval
         self.isas: tuple[type[BaseISA], ...]
         if args.isa is not None:
-            self.isas = tuple(ISA_NAME_TO_CLASS[name] for name in args.isa if name in ISA_NAME_TO_CLASS)
+            self.isas = tuple(BaseISA.from_name(name) for name in args.isa if BaseISA.exists(name))
         else:
             self.isas = ()
         self.data_type: DataType = args.data_type
@@ -152,7 +152,7 @@ class ProfileConfig(InsertsArguments):
             "--isa",
             default=None,
             nargs="+",
-            choices=list(ISA_NAME_TO_CLASS.keys()),
+            choices=BaseISA.names(),
             metavar="ISA",
             help="ISA(s) the application exercises (e.g., x86_avx2 x86_sse x86_scalar). "
             "Only the FP_ARITH counters matching these widths will be requested, "

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -155,9 +155,9 @@ Based on its position relative to the roofline, a region's performance character
 
 | Position | Meaning | What to do |
 |---|---|---|
-| **On or near the compute ceiling** | Compute-bound — the kernel achieves peak FLOP/s for the available threads/ISA. | Vectorize the code and/or increase thread count. |
-| **Below a memory-bandwidth ceiling** | Memory-bound — performance is likely limited by data movement from that memory level. | Improve data locality, use a cache-friendly data layout, or restructure the loop to reduce traffic. Increased thread count can help if that memory level isn't saturated yet. |
-| **Far below either ceiling** | Latency-bound or serialisation overhead — the kernel is not exploiting the hardware's throughput capacity. | Inspect the generated code for pipeline stalls, long-latency instructions, or insufficient ILP. |
+| **Left of the L1 ridge-point** | Memory-bound — the kernel cannot reach the compute ceiling. | Improve data locality, use a cache-friendly data layout, or restructure the loop to reduce traffic. Increased thread count or vectorization can help if that memory level isn't saturated yet. |
+| **Right of the DRAM ridge-point** | Compute-bound — the kernel is limited by the available compute resources. | Vectorize the code and/or increase thread count. |
+| **Between the L1 and DRAM ridge-points** | Mixed — may be bottlenecked by either memory or compute resources. | Use the techniques from both of the previous categories. |
 
 The **arithmetic intensity** (x-axis, FLOP/Byte) is a key metric: higher is usually better, making memory bottlenecks less likely.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "carm-roofline"
-version = "1.0.4"
+version = "1.0.5"
 description = "CARM: Cache-Aware Roofline Model benchmarking and visualization toolkit"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/test_config.cfg
+++ b/test_config.cfg
@@ -1,4 +1,0 @@
-name=venus
-l1_cache=32
-l2_cache=1024
-l3_cache=25344


### PR DESCRIPTION
- Refactor ISA registration from a manual tuple/dict in `__init__.py` to auto-registration via `__init_subclass__` with `register=True` on each concrete ISA class
- Persist GUI settings (`normalize_by_threads`, `marker_scale_factor`) to a JSON file across sessions, with load-on-startup and save-on-change
- Export plot as SVG instead of PNG via Plotly's `toImageButtonOptions`
- Assign distinct marker symbols per application in roofline plots, consistent across all roofs
- Rewrite "Interpret the results" quickstart section using ridge-point classification (left of L1, between ridge-points, right of DRAM)
- Update `AGENTS.md` to document the new ISA registration pattern and enforce mypy/ruff as a hard QA gate
- Remove unused `test_config.cfg` and stale `ISA_NAME_TO_CLASS` import in `profiling/config.py`